### PR TITLE
fix(sgcc): 修复跨平台抓取、鉴权回放与成功误判

### DIFF
--- a/app/sgcc/README.md
+++ b/app/sgcc/README.md
@@ -2,57 +2,85 @@
   <img src="https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png" width="80" alt="网上国网" />
 </p>
 
-# 网上国网
+# 网上国网（测试）
 
-国家电网「网上国网」(95598)App 积分每日签到。
+国家电网「网上国网」App 积分每日签到。脚本不保存账号密码，而是复用 App 的鉴权头与签到加密请求。
 
-## 文件
+> 当前仍是测试版：已修复跨平台存储、抓取规则和成功误判，但签到业务结果本身是加密响应，仍需在 App 积分页核对是否实际签到/加分。
 
-- `sgcc.js` — cron 签到主脚本(复用抓到的签到请求,免账密/登录/验证码)
-- `sgcc.cookie.js` — Cookie + 签到请求抓取(http-request 重写)
+## 工作方式
 
-## 使用步骤
+需要本地保存两份数据：
 
-1. 按下方对应平台配置,开启重写脚本 + cron(或直接导入 `sgcc.plugin` 一键配置);需先开启 MITM 并安装信任 CA 证书
-2. 打开「网上国网」App → 进入「我的 / 积分签到」页(进页面会自动签到,同时触发抓取)
-3. 收到两条通知 `✅ 网上国网 Cookie 获取成功` + `✅ 网上国网 签到请求已抓` 即抓取成功
-4. cron 会按计划自动签到:成功推 `✅`,Cookie 失效推 `⚠️`(再开 App 进签到页即自动重抓)
+| 数据 | 本地键 | 怎么抓 |
+|---|---|---|
+| 鉴权头 | `sgcc_data` | 开启抓取后进入 App「我的 / 积分」等页面即可 |
+| 签到请求 | `sgcc_signin` | **必须在当天尚未签到时**进入积分签到页，让 App 发出真实签到提交请求 |
+
+签到脚本会刷新 `timestamp`，重算 `SM3(skey + data + timestamp)`，再提交已抓到的加密请求。
+
+## 首次使用
+
+1. 配置对应平台的 MITM、两条抓取规则和定时任务；安装并信任 CA 证书。
+2. 开启抓取规则，打开网上国网 App 并登录。
+3. 先进入「我的 / 积分」页，收到 `✅ 网上国网鉴权已抓`。
+4. 在**尚未签到的一天**进入积分签到页，收到 `✅ 网上国网签到请求已抓`。
+5. 抓齐后关闭抓取规则；定时任务继续保留。
+6. 定时通知显示“请求已被服务器受理”后，到 App 积分页核对一次实际签到与加分。
+
+如果当天已经手动签到，App 不会再发出签到提交请求；等次日未签到时再抓，不是重复开关 MITM 就能补出来。
 
 ## Loon
 
+推荐直接导入 `sgcc.plugin`。插件中：
+
+- `抓取凭据` 默认关闭，首次抓取或失效时再开。
+- `定时签到` 默认开启。
+- 定时参数默认 `30 8 * * *`。
+- 随机延迟默认 `0~300` 秒，可改为 `0` 关闭。
+
+裸配置规则如下（插件已包含这些内容）：
+
 ```ini
 [MITM]
 hostname = csc-service.sgcc.com.cn
 
 [Script]
-http-request ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/ tag=网上国网 Cookie, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=true, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
-
-cron "30 8 * * *" script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enable=true
+http-request ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/.+\/member\/(?!m1\/0103514(?:\?|$)) tag=网上国网鉴权, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=false, timeout=10, enable=true
+http-request ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/osg-omgmt1042\/member\/m1\/0103514(?:\?.*)?$ tag=网上国网签到请求, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=true, timeout=10, enable=true
+cron "30 8 * * *" script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, timeout=420, argument=[300], enable=true
 ```
+
+Loon 的 `http-request` 在 `requires-body=true` 时才能读取 `$request.body`，这是抓取签到请求的必要条件。
 
 ## Surge
 
+普通 member 请求和签到提交请求分开抓；不要把所有 member 请求都设为 `requires-body=true`。
+
 ```ini
 [MITM]
-hostname = csc-service.sgcc.com.cn
+hostname = %APPEND% csc-service.sgcc.com.cn
 
 [Script]
-网上国网 Cookie = type=http-request,pattern=^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/,requires-body=true,max-size=0,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js,img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
-
-网上国网签到 = type=cron,cronexp=30 8 * * *,timeout=60,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js,img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
+网上国网鉴权 = type=http-request,pattern=^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/.+\/member\/(?!m1\/0103514(?:\?|$)),requires-body=false,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
+网上国网签到请求 = type=http-request,pattern=^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/osg-omgmt1042\/member\/m1\/0103514(?:\?.*)?$,requires-body=true,max-size=0,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
+网上国网签到 = type=cron,cronexp="30 8 * * *",timeout=420,argument=300,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js
 ```
 
 ## Quantumult X
 
+精确的签到 Body 规则放在普通 Header 规则前面。抓取脚本使用 `$prefs` 写入，已修复“通知成功但 BoxJS/定时任务读不到”的问题。
+
 ```ini
-[MITM]
+[mitm]
 hostname = csc-service.sgcc.com.cn
 
 [rewrite_local]
-^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/ url script-request-body https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
+^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/osg-omgmt1042\/member\/m1\/0103514(?:\?.*)?$ url script-request-body https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
+^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/.+\/member\/(?!m1\/0103514(?:\?|$)) url script-request-header https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
 
 [task_local]
-30 8 * * * https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enabled=true
+30 8 * * * https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, argument=300, enabled=true
 ```
 
 ## Stash
@@ -62,38 +90,48 @@ cron:
   script:
     - name: 网上国网签到
       cron: '30 8 * * *'
-      timeout: 60
+      timeout: 420
 
 http:
   mitm:
-    - "csc-service.sgcc.com.cn"
+    - csc-service.sgcc.com.cn
   script:
-    - match: ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/
-      name: 网上国网 Cookie
+    - match: ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/osg-omgmt1042\/member\/m1\/0103514(?:\?.*)?$
+      name: 网上国网签到请求
       type: request
       require-body: true
+    - match: ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/.+\/member\/(?!m1\/0103514(?:\?|$))
+      name: 网上国网鉴权
+      type: request
+      require-body: false
 
 script-providers:
   网上国网签到:
     url: https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js
     interval: 86400
+  网上国网抓取:
+    url: https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
+    interval: 86400
 ```
 
-## 实现细节
+## 结果怎么判断
 
-- **鉴权 = 抓取的 Cookie**(进 App 签到页时自动带的 t + 设备头),由 `sgcc.cookie.js` 抓取存本地
-- **签到 = 复用抓到的"提交签到"请求**:cron 取出请求体、重算时间戳后提交,**免账号密码、免登录、免图形验证码**
-- **数据全在本地**(BoxJS),仓库与脚本不含任何账号数据;脚本可共享,各人抓各自 Cookie
-- **响应加密**,脚本只判签到成功/失败,**读不到积分数字**(积分到 App 查看)
+- `✅ 请求已被服务器受理`：HTTP 返回中存在 `encryptData`，说明网关接受并返回了加密业务响应；**不等于已解密确认签到成功**。
+- `⚠️ 服务器未受理请求`：鉴权、签到请求或接口状态可能失效；重新抓取后再试。
+- `⚠️ 缺少鉴权 / 签到请求`：通知会指出具体缺哪一份，不再笼统显示“没有 Cookie”。
 
-## 维护记录
+## 2026-08-13 修复
 
-| 日期 | 变更 |
-|---|---|
-| 2026-06-22 | 初版:复用签到请求 + 本地抓 Cookie,免账密/登录/验证码;实测连续多天可签,Cookie ≥4.5 天 |
+- Quantumult X 抓取改用 `$prefs`，并在通知前写后回读校验。
+- 补回签到回放缺失的 `authorization` Header。
+- 把普通鉴权与签到 Body 拆成两条规则，兼容无 `:28630` 的 URL 形式。
+- 不再把任意 `encryptData` 误报为“今日签到完成”。
+- 只对网络错误和 HTTP 5xx 重试，避免业务拒绝连续重放。
+- Loon 插件增加抓取开关、定时开关、Cron 与随机延迟参数。
 
 ## 已知限制
 
-- **Cookie 会失效**:失效时签到脚本推 `⚠️` 提醒,开 App 进积分签到页即自动重抓(实测有效期 ≥4.5 天,无需频繁操作)
-- **读不到积分数字**:签到响应加密,脚本只判成功/失败,具体积分与连签天数请到 App 查看
-- **目前仅 Loon 实测**:其他平台配置已按规范提供,未逐一验证
+- Cookie/鉴权会失效，失效后需重新抓取。
+- 已签到当天无法首次抓到 `sgcc_signin`。
+- 当前不解密业务响应，积分、奖励、连续天数需到 App 查看。
+- Loon/QX/Surge 的运行时与规则已做本地模拟测试；真实 App 抓取、跨日回放和实际加分仍需真机验证。

--- a/app/sgcc/sgcc.cookie.js
+++ b/app/sgcc/sgcc.cookie.js
@@ -1,62 +1,144 @@
 /**
- * 网上国网 · Cookie 抓取
+ * 网上国网 · 凭据抓取
  *
- * 抓取:打开「网上国网」App → 进「我的 / 积分签到」页,抓 Cookie(t/设备头)+ 签到请求(供 cron 复用)
+ * 抓取两类数据：
+ * 1. 任意 member 请求中的鉴权头（sgcc_data）
+ * 2. 签到提交请求 m1/0103514 的加密信封（sgcc_signin）
  *
  * @Author: MaYIHEI <https://github.com/MaYIHEI/paperclip>
  * @Channel: Telegram 频道 https://t.me/mayihei
- * @Updated: 2026-06-22
+ * @Updated: 2026-08-13
  */
 
-const $ = new Env("网上国网 [Cookie]");
+const SCRIPT_VERSION = "2026-08-13.r2";
+const KEY_AUTH = "sgcc_data";
+const KEY_SIGNIN = "sgcc_signin";
+const SIGNIN_PATH = "/osg-omgmt1042/member/m1/0103514";
+const AUTH_KEYS = [
+  "authorization", "t", "userid", "device_token", "appguid", "appguidnew",
+  "devicetokentx", "devicetokentxtime", "wtoken", "appcode", "os", "version",
+  "ip", "province", "language", "wsgwtype", "accessmethod", "user-agent"
+];
 
-const KEY = "sgcc_data";                                   // Cookie:t + 设备头
-const KEY_ENV = "sgcc_signin";                             // 签到请求体 {data,skey,path}
-const SIGNIN_PATH = "/osg-omgmt1042/member/m1/0103514";    // 进签到页时自动触发的"提交签到"请求
-const WANT = ["authorization","t","userid","device_token","appguid","appguidnew","devicetokentx","devicetokentxtime","wtoken","appcode","os","version","ip","province","language","wsgwtype","accessmethod","user-agent"];
+const runtime = detectRuntime();
 
-// http-request 里只有 $persistentStore 可用($httpClient/$loon 可能 undefined),存储走原生
-function read(k){ return typeof $persistentStore !== "undefined" ? $persistentStore.read(k) : null; }
-function write(v,k){ return typeof $persistentStore !== "undefined" ? $persistentStore.write(v,k) : false; }
+function detectRuntime() {
+  if (typeof $task !== "undefined" && typeof $prefs !== "undefined") return "Quantumult X";
+  if (typeof $persistentStore !== "undefined") return "Surge/Loon/Stash";
+  return "Unknown";
+}
 
-!(function main(){
-  if (typeof $request === "undefined") { $.log("[ERROR] 该脚本仅作为 http-request 重写脚本运行"); return $.done(); }
+function read(key) {
+  if (runtime === "Quantumult X") return $prefs.valueForKey(key);
+  if (typeof $persistentStore !== "undefined") return $persistentStore.read(key);
+  return null;
+}
+
+function write(value, key) {
+  if (runtime === "Quantumult X") return $prefs.setValueForKey(value, key);
+  if (typeof $persistentStore !== "undefined") return $persistentStore.write(value, key);
+  return false;
+}
+
+function notify(title, subtitle, body) {
+  if (typeof $notify !== "undefined") $notify(title, subtitle || "", body || "");
+  else if (typeof $notification !== "undefined") $notification.post(title, subtitle || "", body || "");
+  console.log([title, subtitle, body].filter(Boolean).join(" | "));
+}
+
+function finish() {
+  if (typeof $done !== "undefined") $done({});
+}
+
+function parseObject(raw) {
+  if (!raw || typeof raw !== "string") return null;
+  try { return JSON.parse(raw); } catch (_) {}
+  try { return JSON.parse(decodeURIComponent(raw)); } catch (_) {}
+  return null;
+}
+
+function saveVerified(key, value) {
+  const encoded = JSON.stringify(value);
+  if (!write(encoded, key)) return false;
+  const stored = read(key);
+  if (!stored) return false;
+  const check = parseObject(stored);
+  return !!check && check._fingerprint === value._fingerprint;
+}
+
+function fingerprint(value) {
+  const text = String(value || "");
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${text.length}:${(hash >>> 0).toString(16)}`;
+}
+
+(function main() {
+  console.log(`[INFO] 网上国网抓取 ${SCRIPT_VERSION} · ${runtime}`);
+  if (typeof $request === "undefined") {
+    notify("⚠️ 网上国网抓取", "运行方式错误", "请通过 http-request 规则触发");
+    return finish();
+  }
+
   try {
-    const url = $request.url || "";
-    const h = $request.headers || {};
-    const low = {};
-    for (const k in h) low[k.toLowerCase()] = h[k];
+    const url = String($request.url || "");
+    const sourceHeaders = $request.headers || {};
+    const headers = {};
+    Object.keys(sourceHeaders).forEach(k => { headers[k.toLowerCase()] = sourceHeaders[k]; });
 
-    // ① 抓"提交签到"请求体(仅 m1/0103514 这一条,需 requires-body)
-    if (url.indexOf(SIGNIN_PATH) > -1) {
-      try {
-        const b = JSON.parse($request.body || "{}");
-        if (b.data && b.skey) {
-          const had = read(KEY_ENV);
-          write(JSON.stringify({ data: b.data, skey: b.skey, path: SIGNIN_PATH }), KEY_ENV);
-          if (!had) $.msg("✅ 网上国网 签到请求已抓", "之后可自动签到", "");
+    let authSaved = false;
+    let signinSaved = false;
+    let signinSeen = false;
+
+    const token = headers.t;
+    const userid = headers.userid;
+    if (token && userid) {
+      const picked = {};
+      AUTH_KEYS.forEach(k => { if (headers[k] != null) picked[k] = headers[k]; });
+      picked._ts = Date.now();
+      picked._fingerprint = fingerprint(token);
+      const previous = parseObject(read(KEY_AUTH));
+      authSaved = saveVerified(KEY_AUTH, picked);
+      if (!authSaved) {
+        notify("⚠️ 网上国网抓取", "鉴权写入失败", `${runtime} 未能回读 ${KEY_AUTH}`);
+      } else if (!previous || previous._fingerprint !== picked._fingerprint) {
+        notify("✅ 网上国网鉴权已抓", `userid: ${String(userid).slice(0, 6)}…${String(userid).slice(-4)}`, "还需抓到签到请求后才能自动签到");
+      }
+    }
+
+    if (url.includes(SIGNIN_PATH)) {
+      signinSeen = true;
+      const body = parseObject(typeof $request.body === "string" ? $request.body : "");
+      if (body && body.data && body.skey) {
+        const envelope = {
+          data: body.data,
+          skey: body.skey,
+          path: SIGNIN_PATH,
+          _ts: Date.now(),
+          _fingerprint: fingerprint(body.skey + body.data)
+        };
+        const previous = parseObject(read(KEY_SIGNIN));
+        signinSaved = saveVerified(KEY_SIGNIN, envelope);
+        if (!signinSaved) {
+          notify("⚠️ 网上国网抓取", "签到请求写入失败", `${runtime} 未能回读 ${KEY_SIGNIN}`);
+        } else if (!previous || previous._fingerprint !== envelope._fingerprint) {
+          notify("✅ 网上国网签到请求已抓", "自动签到所需数据已齐", "抓取开关现在可以关闭");
         }
-      } catch (e) {}
+      } else {
+        console.log(`[WARN] 命中签到接口但请求体不可用，body长度=${String($request.body || "").length}`);
+        notify("⚠️ 网上国网抓取", "命中签到接口但没有请求体", "确认规则启用 requires-body，并在未签到当天重试");
+      }
     }
 
-    // ② 抓 Cookie 头(每次请求都带,t 未变则静默,避免刷屏)
-    const t = low["t"], uid = low["userid"];
-    if (!t || !uid) return $.done();
-    let prevT = null;
-    try { prevT = JSON.parse(read(KEY) || "{}").t; } catch (e) {}
-    const picked = {};
-    WANT.forEach(k => { if (low[k] != null) picked[k] = low[k]; });
-    picked._ts = Date.now();
-    write(JSON.stringify(picked), KEY);
-    if (t !== prevT) {
-      $.msg("✅ 网上国网 Cookie 获取成功", `userid: ${uid.slice(0,6)}…${uid.slice(-4)}`, `t: ${t.slice(0,6)}…${t.slice(-4)}  共 ${Object.keys(picked).length-1} 项`);
-    }
-    $.done();
-  } catch (e) {
-    $.msg("⚠️ 网上国网 抓取异常", e.message || String(e), "");
-    $.done();
+    if (!token || !userid) console.log("[INFO] 当前请求没有完整 t/userid，未更新鉴权");
+    if (!signinSeen) console.log("[INFO] 当前请求不是签到提交，仅尝试更新鉴权");
+    console.log(`[INFO] 保存结果 auth=${authSaved} signin=${signinSaved}`);
+    finish();
+  } catch (error) {
+    notify("⚠️ 网上国网抓取异常", error.message || String(error), "");
+    finish();
   }
 })();
-
-// prettier-ignore
-function Env(t,e){class s{constructor(t){this.env=t}send(t,e="GET"){t="string"==typeof t?{url:t}:t;let s=this.get;return"POST"===e&&(s=this.post),new Promise((e,a)=>{s.call(this,t,(t,s,r)=>{t?a(t):e(s)})})}get(t){return this.send.call(this.env,t)}post(t){return this.send.call(this.env,t,"POST")}}return new class{constructor(t,e){this.name=t,this.http=new s(this),this.data=null,this.dataFile="box.dat",this.logs=[],this.isMute=!1,this.isNeedRewrite=!1,this.logSeparator="\n",this.encoding="utf-8",this.startTime=(new Date).getTime(),Object.assign(this,e),this.log("",`🔔${this.name}, 开始!`)}getEnv(){return"undefined"!=typeof $environment&&$environment["surge-version"]?"Surge":"undefined"!=typeof $environment&&$environment["stash-version"]?"Stash":"undefined"!=typeof module&&module.exports?"Node.js":"undefined"!=typeof $task?"Quantumult X":"undefined"!=typeof $loon?"Loon":"undefined"!=typeof $rocket?"Shadowrocket":void 0}isNode(){return"Node.js"===this.getEnv()}isQuanX(){return"Quantumult X"===this.getEnv()}isSurge(){return"Surge"===this.getEnv()}isLoon(){return"Loon"===this.getEnv()}isShadowrocket(){return"Shadowrocket"===this.getEnv()}isStash(){return"Stash"===this.getEnv()}toObj(t,e=null){try{return JSON.parse(t)}catch{return e}}toStr(t,e=null){try{return JSON.stringify(t)}catch{return e}}getjson(t,e){let s=e;const a=this.getdata(t);if(a)try{s=JSON.parse(this.getdata(t))}catch{}return s}setjson(t,e){try{return this.setdata(JSON.stringify(t),e)}catch{return!1}}getScript(t){return new Promise(e=>{this.get({url:t},(t,s,a)=>e(a))})}loaddata(){if(!this.isNode())return{};{this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),e=this.path.resolve(process.cwd(),this.dataFile),s=this.fs.existsSync(t),a=!s&&this.fs.existsSync(e);if(!s&&!a)return{};{const a=s?t:e;try{return JSON.parse(this.fs.readFileSync(a))}catch(t){return{}}}}}writedata(){if(this.isNode()){this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),e=this.path.resolve(process.cwd(),this.dataFile),s=this.fs.existsSync(t),a=!s&&this.fs.existsSync(e),r=JSON.stringify(this.data);s?this.fs.writeFileSync(t,r):a?this.fs.writeFileSync(e,r):this.fs.writeFileSync(t,r)}}getdata(t){return this.getval(t)}setdata(t,e){return this.setval(t,e)}getval(t){switch(this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":return $persistentStore.read(t);case"Quantumult X":return $prefs.valueForKey(t);case"Node.js":return this.data=this.loaddata(),this.data[t];default:return this.data&&this.data[t]||null}}setval(t,e){switch(this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":return $persistentStore.write(t,e);case"Quantumult X":return $prefs.setValueForKey(t,e);case"Node.js":return this.data=this.loaddata(),this.data[e]=t,this.writedata(),!0;default:return this.data&&this.data[e]||null}}initGotEnv(t){this.got=this.got?this.got:require("got"),this.cktough=this.cktough?this.cktough:require("tough-cookie"),this.ckjar=this.ckjar?this.ckjar:new this.cktough.CookieJar,t&&(t.headers=t.headers?t.headers:{},void 0===t.headers.Cookie&&void 0===t.cookieJar&&(t.cookieJar=this.ckjar))}get(t,e=(()=>{})){switch(t.headers&&(delete t.headers["Content-Type"],delete t.headers["Content-Length"],delete t.headers["content-type"],delete t.headers["content-length"]),t.params&&(t.url+="?"+this.queryStr(t.params)),this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":default:this.isSurge()&&this.isNeedRewrite&&(t.headers=t.headers||{},Object.assign(t.headers,{"X-Surge-Skip-Scripting":!1})),$httpClient.get(t,(t,s,a)=>{!t&&s&&(s.body=a,s.statusCode=s.status?s.status:s.statusCode,s.status=s.statusCode),e(t,s,a)});break;case"Quantumult X":this.isNeedRewrite&&(t.opts=t.opts||{},Object.assign(t.opts,{hints:!1})),$task.fetch(t).then(t=>{const{statusCode:s,statusCode:a,headers:r,body:i,bodyBytes:o}=t;e(null,{status:s,statusCode:a,headers:r,body:i,bodyBytes:o},i,o)},t=>e(t&&t.error||"UndefinedError"));break;case"Node.js":let s=require("iconv-lite");this.initGotEnv(t),this.got(t).on("redirect",(t,e)=>{try{if(t.headers["set-cookie"]){const s=t.headers["set-cookie"].map(this.cktough.Cookie.parse).toString();s&&this.ckjar.setCookieSync(s,null),e.cookieJar=this.ckjar}}catch(t){this.logErr(t)}}).then(t=>{const{statusCode:a,statusCode:r,headers:i,rawBody:o}=t,n=s.decode(o,this.encoding);e(null,{status:a,statusCode:r,headers:i,rawBody:o,body:n},n)},t=>{const{message:a,response:r}=t;e(a,r,r&&s.decode(r.rawBody,this.encoding))})}}post(t,e=(()=>{})){const s=t.method?t.method.toLocaleLowerCase():"post";switch(t.body&&t.headers&&!t.headers["Content-Type"]&&!t.headers["content-type"]&&(t.headers["content-type"]="application/x-www-form-urlencoded"),t.headers&&(delete t.headers["Content-Length"],delete t.headers["content-length"]),this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":default:this.isSurge()&&this.isNeedRewrite&&(t.headers=t.headers||{},Object.assign(t.headers,{"X-Surge-Skip-Scripting":!1})),$httpClient[s](t,(t,s,a)=>{!t&&s&&(s.body=a,s.statusCode=s.status?s.status:s.statusCode,s.status=s.statusCode),e(t,s,a)});break;case"Quantumult X":t.method=s,this.isNeedRewrite&&(t.opts=t.opts||{},Object.assign(t.opts,{hints:!1})),$task.fetch(t).then(t=>{const{statusCode:s,statusCode:a,headers:r,body:i,bodyBytes:o}=t;e(null,{status:s,statusCode:a,headers:r,body:i,bodyBytes:o},i,o)},t=>e(t&&t.error||"UndefinedError"));break;case"Node.js":let a=require("iconv-lite");this.initGotEnv(t);const{url:r,...i}=t;this.got[s](r,i).then(t=>{const{statusCode:s,statusCode:r,headers:i,rawBody:o}=t,n=a.decode(o,this.encoding);e(null,{status:s,statusCode:r,headers:i,rawBody:o,body:n},n)},t=>{const{message:s,response:r}=t;e(s,r,r&&a.decode(r.rawBody,this.encoding))})}}time(t,e=null){const s=e?new Date(e):new Date;let a={"M+":s.getMonth()+1,"d+":s.getDate(),"H+":s.getHours(),"m+":s.getMinutes(),"s+":s.getSeconds(),"q+":Math.floor((s.getMonth()+3)/3),S:s.getMilliseconds()};/(y+)/.test(t)&&(t=t.replace(RegExp.$1,(s.getFullYear()+"").substr(4-RegExp.$1.length)));for(let e in a)new RegExp("("+e+")").test(t)&&(t=t.replace(RegExp.$1,1==RegExp.$1.length?a[e]:("00"+a[e]).substr((""+a[e]).length)));return t}queryStr(t){let e="";for(const s in t){let a=t[s];null!=a&&""!==a&&("object"==typeof a&&(a=JSON.stringify(a)),e+=`${s}=${a}&`)}return e=e.substring(0,e.length-1),e}msg(e=t,s="",a="",r){const i=t=>{switch(typeof t){case void 0:return t;case"string":switch(this.getEnv()){case"Surge":case"Stash":default:return{url:t};case"Loon":case"Shadowrocket":return t;case"Quantumult X":return{"open-url":t};case"Node.js":return}case"object":switch(this.getEnv()){case"Surge":case"Stash":case"Shadowrocket":default:{let e=t.url||t.openUrl||t["open-url"];return{url:e}}case"Loon":{let e=t.openUrl||t.url||t["open-url"],s=t.mediaUrl||t["media-url"];return{openUrl:e,mediaUrl:s}}case"Quantumult X":{let e=t["open-url"]||t.url||t.openUrl,s=t["media-url"]||t.mediaUrl,a=t["update-pasteboard"]||t.updatePasteboard;return{"open-url":e,"media-url":s,"update-pasteboard":a}}case"Node.js":return}default:return}};if(!this.isMute)switch(this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":default:$notification.post(e,s,a,i(r));break;case"Quantumult X":$notify(e,s,a,i(r));break;case"Node.js":}if(!this.isMuteLog){let t=["","==============📣系统通知📣=============="];t.push(e),s&&t.push(s),a&&t.push(a),console.log(t.join("\n")),this.logs=this.logs.concat(t)}}log(...t){t.length>0&&(this.logs=[...this.logs,...t]),console.log(t.join(this.logSeparator))}logErr(t,e){switch(this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":case"Quantumult X":default:this.log("",`❗️${this.name}, 错误!`,t);break;case"Node.js":this.log("",`❗️${this.name}, 错误!`,t.stack)}}wait(t){return new Promise(e=>setTimeout(e,t))}done(t={}){const e=(new Date).getTime(),s=(e-this.startTime)/1e3;switch(this.log("",`🔔${this.name}, 结束! 🕛 ${s} 秒`),this.log(),this.getEnv()){case"Surge":case"Loon":case"Stash":case"Shadowrocket":case"Quantumult X":default:$done(t);break;case"Node.js":process.exit(1)}}}(t,e)}

--- a/app/sgcc/sgcc.js
+++ b/app/sgcc/sgcc.js
@@ -6,48 +6,9 @@
  *
  * @Author: MaYIHEI <https://github.com/MaYIHEI/paperclip>
  * @Channel: Telegram 频道 https://t.me/mayihei
- * @Updated: 2026-06-22
+ * @Updated: 2026-08-13
  *
- * ===== Loon =====
- * [MITM]
- * hostname = csc-service.sgcc.com.cn
- * [Script]
- * http-request ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/ tag=网上国网 Cookie, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=true, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
- * cron "30 8 * * *" script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enable=true
- *
- * ===== Surge =====
- * [MITM]
- * hostname = csc-service.sgcc.com.cn
- * [Script]
- * 网上国网 Cookie = type=http-request,pattern=^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/,requires-body=true,max-size=0,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js,img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
- * 网上国网签到 = type=cron,cronexp=30 8 * * *,timeout=60,script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js,img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
- *
- * ===== Quantumult X =====
- * [MITM]
- * hostname = csc-service.sgcc.com.cn
- * [rewrite_local]
- * ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/ url script-request-body https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js
- * [task_local]
- * 30 8 * * * https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, tag=网上国网签到, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enabled=true
- *
- * ===== Stash =====
- * cron:
- *   script:
- *     - name: 网上国网签到
- *       cron: '30 8 * * *'
- *       timeout: 60
- * http:
- *   mitm:
- *     - "csc-service.sgcc.com.cn"
- *   script:
- *     - match: ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/
- *       name: 网上国网 Cookie
- *       type: request
- *       require-body: true
- * script-providers:
- *   网上国网签到:
- *     url: https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js
- *     interval: 86400
+ * 平台配置与首次抓取步骤见同目录 README.md；Loon 建议直接导入 sgcc.plugin。
  */
 
 // ----- SM3(sm-crypto,用于重算 sign)-----
@@ -58,7 +19,7 @@ var sm3=(typeof __SM3==='function')?__SM3:(__SM3.sm3||__SM3.default||__SM3);
 
 
 const $ = new Env("网上国网");
-const SCRIPT_VERSION = "2026-06-22.r1"; // 改一次 +1,确认拉到最新版
+const SCRIPT_VERSION = "2026-08-13.r2"; // 改一次 +1,确认拉到最新版
 $.log(`[INFO] 脚本版本 ${SCRIPT_VERSION}`);
 
 const KEY_HDR = "sgcc_data";    // Cookie:t + 设备头
@@ -66,7 +27,26 @@ const KEY_ENV = "sgcc_signin";  // 签到请求体 {data,skey,path}
 const MAX_RETRY = 3;
 const DEBUG = JSON.parse($.getdata("sgcc_debug") || "false");
 
-const AUTH_KEYS = ["t","userid","device_token","devicetokentx","devicetokentxtime","appguid","appguidnew","wtoken","appcode","os","version","ip","province","language","wsgwtype","accessmethod","user-agent"];
+function getJitterMax() {
+  if (typeof $argument === "undefined" || $argument == null) return 0;
+  let value = $argument;
+  if (Array.isArray(value)) value = value[0];
+  else if (typeof value === "object") value = value.jitterMax != null ? value.jitterMax : value[0];
+  else if (typeof value === "string") {
+    const text = value.trim();
+    try {
+      const parsed = JSON.parse(text);
+      value = Array.isArray(parsed) ? parsed[0] : (parsed && parsed.jitterMax != null ? parsed.jitterMax : parsed);
+    } catch (e) {
+      const matched = text.match(/(?:jitterMax\s*[=:]\s*)?(\d+)/i);
+      value = matched ? matched[1] : 0;
+    }
+  }
+  const seconds = Number(value);
+  return Number.isFinite(seconds) ? Math.max(0, Math.min(600, Math.floor(seconds))) : 0;
+}
+
+const AUTH_KEYS = ["authorization","t","userid","device_token","devicetokentx","devicetokentxtime","appguid","appguidnew","wtoken","appcode","os","version","ip","province","language","wsgwtype","accessmethod","user-agent"];
 
 !(function main(){
   // 清除 Cookie(BoxJS 开关):清空已抓 Cookie + 签到请求,开关自动复位
@@ -75,10 +55,16 @@ const AUTH_KEYS = ["t","userid","device_token","devicetokentx","devicetokentxtim
     $.msg("网上国网签到", "", "✅ Cookie 已清除,请重新开 App 进积分签到页抓取"); return $.done();
   }
   const rawH = $.getdata(KEY_HDR), rawE = $.getdata(KEY_ENV);
-  if (!rawH || !rawE) { $.msg("⚠️ 网上国网签到", "缺少 Cookie 或签到请求", "打开 App 进积分签到页抓取(收到两条通知即可)"); return $.done(); }
+  if (!rawH || !rawE) {
+    const missing = [!rawH ? "鉴权" : "", !rawE ? "签到请求" : ""].filter(Boolean).join(" + ");
+    const hint = !rawH
+      ? "开启抓取后进 App 积分页；仍缺签到请求时需在未签到当天进入签到页"
+      : "鉴权已保存；需在未签到当天进入签到页，抓到真实提交请求";
+    $.msg("⚠️ 网上国网签到", "缺少" + missing, hint); return $.done();
+  }
   let hdr, env0;
-  try { hdr = JSON.parse(rawH); env0 = JSON.parse(rawE); } catch (e) { $.msg("⚠️ 网上国网签到", "Cookie 解析失败,请重抓", ""); return $.done(); }
-  if (!hdr.t || !hdr.userid || !env0.data || !env0.skey) { $.msg("⚠️ 网上国网签到", "Cookie/签到请求字段缺失,请重抓", ""); return $.done(); }
+  try { hdr = JSON.parse(rawH); env0 = JSON.parse(rawE); } catch (e) { $.msg("⚠️ 网上国网签到", "本地数据解析失败,请清除后重抓", ""); return $.done(); }
+  if (!hdr.t || !hdr.userid || !env0.data || !env0.skey) { $.msg("⚠️ 网上国网签到", "鉴权/签到请求字段缺失,请重抓", ""); return $.done(); }
 
   const path = env0.path || "/osg-omgmt1042/member/m1/0103514";
   const headers = { "content-type": "application/json", "accept": "application/json;charset=UTF-8" };
@@ -95,16 +81,22 @@ const AUTH_KEYS = ["t","userid","device_token","devicetokentx","devicetokentxtim
         if (n < MAX_RETRY) { setTimeout(() => attempt(n + 1), 3000); return; }
         $.msg("⚠️ 网上国网签到", "网络错误,重试" + MAX_RETRY + "次失败", String(err).slice(0, 80)); return $.done();
       }
-      let ok = false, msg = String(data || "").slice(0, 140);
-      try { const j = JSON.parse(data); ok = !!j.encryptData; if (!ok) msg = (j.message || "") + " [" + (j.code || "") + "]"; } catch (e) {}
-      // 有 encryptData = 成功
-      if (ok) { $.msg("✅ 网上国网签到", "今日签到完成 ✓", ""); return $.done(); }
-      // 服务器对所有失败都只回"系统正忙",无法靠码区分;重试应对偶发,持久失败即判 Cookie 失效
-      if (n < MAX_RETRY) { setTimeout(() => attempt(n + 1), 3000); return; }
-      $.msg("⚠️ 网上国网签到", "签到失败(重试" + MAX_RETRY + "次)· Cookie 多半失效", "开 App 进积分签到页重抓;若 App 也异常则服务器问题 | " + msg); $.done();
+      let accepted = false, msg = String(data || "").slice(0, 140);
+      try { const j = JSON.parse(data); accepted = !!j.encryptData; if (!accepted) msg = (j.message || "") + " [" + (j.code || "") + "]"; } catch (e) {}
+      // encryptData 只能证明网关返回了加密业务响应；未解密前不能据此断言签到成功。
+      if (accepted) {
+        $.msg("✅ 网上国网签到", "请求已被服务器受理", "业务结果为加密响应，请在 App 积分页核对是否签到/加分"); return $.done();
+      }
+      // 仅对网络错误和明确 5xx 做重试；鉴权/业务拒绝盲目重试只会放大风控。
+      const status = Number(resp && (resp.status || resp.statusCode)) || 0;
+      if (status >= 500 && n < MAX_RETRY) { setTimeout(() => attempt(n + 1), 3000); return; }
+      $.msg("⚠️ 网上国网签到", "服务器未受理请求" + (status ? " · HTTP " + status : ""), "可能是鉴权/签到请求失效；请重新抓取 | " + msg); $.done();
     });
   };
-  attempt(1);
+  const jitterMax = getJitterMax();
+  const delayMs = jitterMax > 0 ? Math.floor(Math.random() * (jitterMax + 1)) * 1000 : 0;
+  if (delayMs > 0) $.log("[INFO] 定时随机延迟 " + Math.floor(delayMs / 1000) + " 秒");
+  if (delayMs > 0) setTimeout(() => attempt(1), delayMs); else attempt(1);
 })();
 
 

--- a/app/sgcc/sgcc.plugin
+++ b/app/sgcc/sgcc.plugin
@@ -1,12 +1,21 @@
 #!name=网上国网签到(测试)
-#!desc=网上国网积分签到。① 开 App 进「我的/积分」页,自动抓 t 存 BoxJS(收到「✅ Cookie 获取成功」即可)② cron 每天 8:30 自动签到(复用信封免公钥);也可在脚本里手动跑。🧪 待验证(t 寿命 + 签到生效)。
+#!desc=网上国网积分签到。抓取分为「鉴权」和「签到请求」两步；签到请求只能在未签到当天进入积分签到页时产生。定时任务只在服务器返回加密业务响应时提示“已受理”，请到 App 核对实际加分。
 #!author=MaYIHEI
-#!homepage=https://github.com/MaYIHEI/paperclip
+#!homepage=https://github.com/MaYIHEI/paperclip/tree/main/app/sgcc
 #!icon=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png
+#!tag=签到,网上国网
+#!loon_version=3.5.1(980)
+
+[Argument]
+captureEnabled = switch,false,tag=抓取凭据,desc=首次使用或凭据失效时开启；抓齐后关闭，避免长期 MITM 抓取
+scriptEnabled = switch,true,tag=定时签到,desc=开启每天定时提交签到请求
+cronExp = input,"30 8 * * *",tag=定时参数,desc=五段 Cron：分 时 日 月 周
+jitterMax = input,"300",tag=随机延迟秒数,desc=定时执行前随机等待 0~600 秒；填 0 关闭
 
 [Script]
-http-request ^https?:\/\/csc-service\.sgcc\.com\.cn:28630\/.+\/member\/ tag=网上国网 Cookie, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=1, timeout=10
-cron "30 8 * * *" tag=网上国网签到, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, timeout=20
+http-request ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/.+\/member\/(?!m1\/0103514(?:\?|$)) tag=网上国网鉴权, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=false, timeout=10, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enable={captureEnabled}
+http-request ^https:\/\/csc-service\.sgcc\.com\.cn(?::28630)?\/osg-omgmt1042\/member\/m1\/0103514(?:\?.*)?$ tag=网上国网签到请求, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.cookie.js, requires-body=true, timeout=10, img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enable={captureEnabled}
+cron {cronExp} tag=网上国网签到, script-path=https://raw.githubusercontent.com/MaYIHEI/paperclip/refs/heads/main/app/sgcc/sgcc.js, timeout=420, argument=[{jitterMax}], img-url=https://raw.githubusercontent.com/MaYIHEI/pin/refs/heads/main/app/sgcc.png, enable={scriptEnabled}
 
 [MITM]
 hostname = csc-service.sgcc.com.cn

--- a/app/sgcc/tests/sgcc.test.js
+++ b/app/sgcc/tests/sgcc.test.js
@@ -1,0 +1,153 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const COOKIE = fs.readFileSync(path.join(ROOT, 'sgcc.cookie.js'), 'utf8');
+const MAIN = fs.readFileSync(path.join(ROOT, 'sgcc.js'), 'utf8');
+
+function runCookie(runtime, request, writeFails = false) {
+  const store = new Map();
+  const notices = [];
+  let done = 0;
+  const base = {
+    console: { log() {} },
+    $request: request,
+    $done() { done += 1; },
+  };
+  if (runtime === 'qx') {
+    base.$task = {};
+    base.$prefs = {
+      valueForKey: key => store.get(key) || null,
+      setValueForKey: (value, key) => writeFails ? false : (store.set(key, value), true),
+    };
+    base.$notify = (...args) => notices.push(args);
+  } else {
+    base.$loon = '3.5.1';
+    base.$persistentStore = {
+      read: key => store.get(key) || null,
+      write: (value, key) => writeFails ? false : (store.set(key, value), true),
+    };
+    base.$notification = { post: (...args) => notices.push(args) };
+  }
+  vm.runInNewContext(COOKIE, base, { filename: 'sgcc.cookie.js' });
+  return { store, notices, done };
+}
+
+function runMain({ runtime = 'loon', responseBody, status = 200, error = null, auth = {}, envelope = {}, argument = [0] }) {
+  const store = new Map([
+    ['sgcc_data', JSON.stringify({
+      authorization: 'Bearer sample', t: 'token-sample', userid: 'user-sample',
+      device_token: 'device-sample', ...auth,
+    })],
+    ['sgcc_signin', JSON.stringify({ data: 'DATA123', skey: 'SKEY456', path: '/osg-omgmt1042/member/m1/0103514', ...envelope })],
+    ['sgcc_debug', 'false'], ['sgcc_clear', 'false'],
+  ]);
+  const notices = [];
+  const requests = [];
+  let done = 0;
+  const base = {
+    console: { log() {} },
+    $argument: argument,
+    setTimeout(fn) { fn(); return 1; },
+    clearTimeout() {},
+    Math,
+    Date,
+  };
+  if (runtime === 'qx') {
+    base.$task = {
+      fetch: req => {
+        requests.push(req);
+        return error ? Promise.reject({ error }) : Promise.resolve({ statusCode: status, headers: {}, body: responseBody });
+      },
+    };
+    base.$prefs = {
+      valueForKey: key => store.get(key) || null,
+      setValueForKey: (value, key) => (store.set(key, value), true),
+    };
+    base.$notify = (...args) => notices.push(args);
+  } else {
+    base.$loon = '3.5.1';
+    base.$persistentStore = {
+      read: key => store.get(key) || null,
+      write: (value, key) => (store.set(key, value), true),
+    };
+    base.$notification = { post: (...args) => notices.push(args) };
+    base.$httpClient = {
+      post(req, callback) {
+        requests.push(req);
+        callback(error, { status }, responseBody);
+      },
+      get() { throw new Error('unexpected GET'); },
+    };
+  }
+  base.$done = () => { done += 1; };
+  vm.runInNewContext(MAIN, base, { filename: 'sgcc.js' });
+  return Promise.resolve().then(() => ({ store, notices, requests, get done() { return done; } }));
+}
+
+(async () => {
+  const signinRequest = {
+    url: 'https://csc-service.sgcc.com.cn:28630/osg-omgmt1042/member/m1/0103514',
+    headers: { Authorization: 'Bearer sample', T: 'token-sample', UserId: 'user-sample', Device_Token: 'device-sample' },
+    body: JSON.stringify({ data: 'DATA123', skey: 'SKEY456', timestamp: 'old', sign: 'old' }),
+  };
+
+  for (const runtime of ['qx', 'loon']) {
+    const result = runCookie(runtime, signinRequest);
+    assert.equal(result.done, 1, `${runtime}: should finish once`);
+    assert.ok(result.store.get('sgcc_data'), `${runtime}: auth must persist`);
+    assert.ok(result.store.get('sgcc_signin'), `${runtime}: envelope must persist`);
+    assert.equal(JSON.parse(result.store.get('sgcc_data')).authorization, 'Bearer sample');
+    assert.equal(result.notices.some(n => n[0].includes('鉴权已抓')), true);
+    assert.equal(result.notices.some(n => n[0].includes('签到请求已抓')), true);
+  }
+
+  const failedWrite = runCookie('qx', signinRequest, true);
+  assert.equal(failedWrite.notices.some(n => n.join(' ').includes('写入失败')), true);
+  assert.equal(failedWrite.notices.some(n => n[0].startsWith('✅')), false, 'failed writes must not report success');
+
+  const accepted = await runMain({ responseBody: JSON.stringify({ encryptData: 'ciphertext' }) });
+  assert.equal(accepted.requests.length, 1);
+  const sent = accepted.requests[0];
+  assert.equal(sent.headers.authorization, 'Bearer sample', 'authorization header must be replayed');
+  const body = JSON.parse(sent.body);
+  const expectedSign = crypto.createHash('sm3').update(body.skey + body.data + body.timestamp).digest('hex');
+  assert.equal(body.sign, expectedSign, 'SM3 sign must match OpenSSL');
+  const acceptedNotice = accepted.notices.find(n => n[0].includes('✅'));
+  assert.ok(acceptedNotice);
+  assert.equal(acceptedNotice[1], '请求已被服务器受理');
+  assert.equal(acceptedNotice.join(' ').includes('今日签到完成'), false, 'encrypted response must not be called confirmed success');
+
+  const rejected = await runMain({ responseBody: JSON.stringify({ code: 'RK1003', message: '系统正忙' }), status: 200 });
+  assert.equal(rejected.requests.length, 1, 'business rejection must not be blindly retried');
+  assert.equal(rejected.notices.some(n => n[1] && n[1].includes('未受理')), true);
+
+  const serverError = await runMain({ responseBody: 'server error', status: 503 });
+  assert.equal(serverError.requests.length, 3, 'HTTP 5xx should retry up to MAX_RETRY');
+
+  const qxAccepted = await runMain({ runtime: 'qx', responseBody: JSON.stringify({ encryptData: 'ciphertext' }), argument: '0' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(qxAccepted.requests.length, 1, 'QX should submit through $task.fetch');
+
+  const plugin = fs.readFileSync(path.join(ROOT, 'sgcc.plugin'), 'utf8');
+  assert.match(plugin, /captureEnabled = switch,false/);
+  assert.match(plugin, /cron \{cronExp\}/);
+  assert.match(plugin, /requires-body=false/);
+  assert.match(plugin, /0103514[^\n]+requires-body=true/);
+  assert.doesNotMatch(plugin, /^generic /m);
+
+  const patterns = [...plugin.matchAll(/^http-request (\S+)/gm)].map(m => new RegExp(m[1].replaceAll('\\/', '/')));
+  assert.equal(patterns.length, 2);
+  assert.equal(patterns[1].test(signinRequest.url), true, 'body rule must match explicit port');
+  assert.equal(patterns[1].test(signinRequest.url.replace(':28630', '')), true, 'body rule must match default port form');
+  assert.equal(patterns[0].test(signinRequest.url), false, 'header rule must exclude sign-in request');
+  assert.equal(patterns[0].test('https://csc-service.sgcc.com.cn:28630/osg-omgmt1042/member/m4/profile'), true);
+
+  console.log('sgcc tests: all passed');
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 背景

结合“能跑就行 Chat”中的实际反馈修复 `app/sgcc`：

- Quantumult X 通知“获取成功”，但 BoxJS/定时任务读不到凭据
- Surge 抓取规则不稳定
- 抓取状态不清楚，当天已签到时无法首次抓到签到请求
- 回放漏发 `authorization`
- 仅凭 `encryptData` 就通知“今日签到完成”，存在成功误判

## 修改

- QX 使用 `$prefs`；Loon/Surge/Stash 使用 `$persistentStore`，通知前写后回读校验
- 拆分普通鉴权 Header 与精确签到 Body 两条抓取规则，兼容带/不带 `:28630`
- 补回 `authorization` Header
- `encryptData` 只报告“服务器已受理，业务结果待 App 核对”
- 业务拒绝不盲目重试，仅网络错误/HTTP 5xx 重试
- Loon 插件增加抓取/定时开关、Cron、0~600 秒随机延迟
- README 明确：首次 `sgcc_signin` 必须在未签到当天抓取
- 新增 Node VM 回归测试，覆盖 QX/Loon 存储、写失败通知、SM3、Header 回放、重试与规则匹配

## 验证

```text
node --check app/sgcc/sgcc.cookie.js
node --check app/sgcc/sgcc.js
node --check app/sgcc/tests/sgcc.test.js
node app/sgcc/tests/sgcc.test.js
# sgcc tests: all passed

git diff --check
# passed
```

## 验证边界

已完成静态语法、跨运行时 VM 与规则匹配验证；尚未拥有真实 App 凭据做真机抓取、跨日回放和实际积分增加验证，因此仍保留“测试”标识，不把 `encryptData` 等同于业务签到成功。